### PR TITLE
Remove full home file system permissions

### DIFF
--- a/edu.princeton.physics.WSJTX.yml
+++ b/edu.princeton.physics.WSJTX.yml
@@ -11,7 +11,6 @@ finish-args:
   - --socket=fallback-x11
   - --device=all
   - --socket=pulseaudio
-  - --filesystem=home
   - --share=network
 cleanup:
   - /man


### PR DESCRIPTION
There is no point in WSJT-X having full home file system access. Opening/saving files can be done without full access to home thanks to the XDG desktop portal. The only downside of this change is that it sadly breaks saved settings and other data for existing users, but it will be redeemed by the benefits of this change + it is better to change this sooner than later.

Closes #21.