### PR TITLE
Update AppStream metadata

### DIFF
--- a/edu.princeton.physics.WSJTX.metainfo.xml
+++ b/edu.princeton.physics.WSJTX.metainfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
+<component type="desktop-application">
     <id>edu.princeton.physics.WSJTX</id>
     <name>wsjtx</name>
     <provides>
@@ -18,7 +18,7 @@
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0+</project_license>
     <url type="bugtracker">https://sourceforge.net/projects/wsjt/lists/wsjt-devel</url>
-    <url type="homepage">https://physics.princeton.edu/pulsar/K1JT/index.html</url>
+    <url type="homepage">https://wsjt.sourceforge.io/wsjtx.html</url>
     <screenshots>
         <screenshot type="default">
             <caption>Main WSJT-X window</caption>


### PR DESCRIPTION
The old homepage URL no longer works. Also fix the component type to use non-deprecated "desktop-application".